### PR TITLE
feat: Input TextField

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
-import type { Preview } from "@storybook/react";
+import type { Preview } from '@storybook/react';
+import '../src/reset.css.ts';
 
 const preview: Preview = {
   parameters: {

--- a/src/ui/form/form-error-message.styles.css.ts
+++ b/src/ui/form/form-error-message.styles.css.ts
@@ -1,0 +1,17 @@
+import { style } from '@vanilla-extract/css';
+import { globalVars } from '../theme.css.ts';
+import { typography } from '../typography.css.ts';
+
+export const formErrorMessageBase = style([
+  typography('body_5_12_r'),
+  {
+    color: globalVars.color.redDanger,
+  },
+]);
+
+export const formErrorMessageContainer = style({
+  display: 'flex',
+  gap: 4,
+  padding: '1.5px 0',
+  alignItems: 'center',
+});

--- a/src/ui/form/form-error-message.tsx
+++ b/src/ui/form/form-error-message.tsx
@@ -1,0 +1,27 @@
+import { type ComponentProps } from 'react';
+import { ErrorCir } from '../../assets/index.ts';
+import { cx } from '../util.ts';
+import * as styles from './form-error-message.styles.css.ts';
+import { useFormField } from './form-field.tsx';
+
+export type FormErrorMessageProps = ComponentProps<'p'>;
+
+export const FormErrorMessage = (props: FormErrorMessageProps) => {
+  const { children, className, ...restProps } = props;
+
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message) : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <div id={formMessageId} className={styles.formErrorMessageContainer}>
+      <ErrorCir />
+      <p {...restProps} className={cx(styles.formErrorMessageBase, className)}>
+        {body}
+      </p>
+    </div>
+  );
+};

--- a/src/ui/form/form-field.tsx
+++ b/src/ui/form/form-field.tsx
@@ -1,0 +1,66 @@
+import { createContext, useContext } from 'react';
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from 'react-hook-form';
+
+export const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue,
+);
+
+export const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+export const FormItemContext = createContext<FormItemContextValue>(
+  {} as FormItemContextValue,
+);
+
+export const useFormField = () => {
+  const fieldContext = useContext(FormFieldContext);
+  const itemContext = useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error('useFormField should be used within <FormField>');
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};

--- a/src/ui/form/form-item.stories.tsx
+++ b/src/ui/form/form-item.stories.tsx
@@ -47,6 +47,8 @@ const meta: Meta<typeof FormField> = {
                 control: form.control as any,
               }}
             />
+            {/* 
+            // error State는 이렇게 관리, storybook에선 보여주기 힘듬
             <FormField
               control={form.control}
               name="username"
@@ -71,7 +73,7 @@ const meta: Meta<typeof FormField> = {
                   <FormErrorMessage />
                 </FormItem>
               )}
-            />
+            /> */}
             <button hidden />
           </form>
         </Form>
@@ -91,6 +93,29 @@ export const First: Story = {
       render={({ field }) => (
         <FormItem>
           <FormLabel>폼 라밸</FormLabel>
+          <InputContainer>
+            <Input {...field} />
+            {field.value && (
+              <InputRightElement>
+                <DeleteCir />
+              </InputRightElement>
+            )}
+          </InputContainer>
+          <FormErrorMessage />
+        </FormItem>
+      )}
+    />
+  ),
+};
+
+export const required: Story = {
+  render: (args) => (
+    <FormField
+      control={args.control}
+      name="username"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel required>폼 라밸</FormLabel>
           <InputContainer>
             <Input {...field} />
             {field.value && (

--- a/src/ui/form/form-item.stories.tsx
+++ b/src/ui/form/form-item.stories.tsx
@@ -1,0 +1,151 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { DeleteCir } from '../../assets/index.ts';
+import { InputContainer } from '../input/input-container.tsx';
+import { InputRightElement } from '../input/input-element.tsx';
+import { Input } from '../input/input.tsx';
+import { FormErrorMessage } from './form-error-message.tsx';
+import { Form, FormField } from './form-field.tsx';
+import { FormItem } from './form-item.tsx';
+import { FormLabel } from './form-label.tsx';
+
+const formSchema = z.object({
+  username: z.string().min(2, {
+    message: 'Username must be at least 2 characters.',
+  }),
+});
+
+const meta: Meta<typeof FormField> = {
+  title: 'ui/FormField',
+  component: FormField,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {},
+  tags: ['autodocs'],
+  decorators: [
+    (Story, context) => {
+      const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+          username: '',
+        },
+      });
+
+      function onSubmit(values: z.infer<typeof formSchema>) {
+        console.log(values);
+      }
+
+      return (
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <Story
+              args={{
+                ...context.args,
+                control: form.control as any,
+              }}
+            />
+            <FormField
+              control={form.control}
+              name="username"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>폼 라밸</FormLabel>
+                  <InputContainer>
+                    {
+                      <Input
+                        {...field}
+                        variant={
+                          form.formState.errors.username ? 'error' : 'default'
+                        }
+                      />
+                    }
+                    {field.value && (
+                      <InputRightElement>
+                        <DeleteCir />
+                      </InputRightElement>
+                    )}
+                  </InputContainer>
+                  <FormErrorMessage />
+                </FormItem>
+              )}
+            />
+            <button hidden />
+          </form>
+        </Form>
+      );
+    },
+  ],
+} satisfies Meta<typeof FormField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const First: Story = {
+  render: (args) => (
+    <FormField
+      control={args.control}
+      name="username"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>폼 라밸</FormLabel>
+          <InputContainer>
+            <Input {...field} />
+            {field.value && (
+              <InputRightElement>
+                <DeleteCir />
+              </InputRightElement>
+            )}
+          </InputContainer>
+          <FormErrorMessage />
+        </FormItem>
+      )}
+    />
+  ),
+};
+
+export const WithoutLabel: Story = {
+  render: (args) => (
+    <FormField
+      control={args.control}
+      name="username"
+      render={({ field }) => (
+        <FormItem>
+          <InputContainer>
+            <Input {...field} />
+            {field.value && (
+              <InputRightElement>
+                <DeleteCir />
+              </InputRightElement>
+            )}
+          </InputContainer>
+          <FormErrorMessage />
+        </FormItem>
+      )}
+    />
+  ),
+};
+
+export const disabledField: Story = {
+  render: (args) => (
+    <FormField
+      control={args.control}
+      name="username"
+      render={({ field }) => (
+        <FormItem>
+          <InputContainer>
+            <Input {...field} disabled />
+            {field.value && (
+              <InputRightElement>
+                <DeleteCir />
+              </InputRightElement>
+            )}
+          </InputContainer>
+          <FormErrorMessage />
+        </FormItem>
+      )}
+    />
+  ),
+};

--- a/src/ui/form/form-item.styles.css.ts
+++ b/src/ui/form/form-item.styles.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
+export const formItemBase = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+});

--- a/src/ui/form/form-item.tsx
+++ b/src/ui/form/form-item.tsx
@@ -1,0 +1,20 @@
+import { type ComponentProps, useId } from 'react';
+import { cx } from '../util.ts';
+import { FormItemContext } from './form-field.tsx';
+import * as styles from './form-item.styles.css.ts';
+
+export type FormItemProps = ComponentProps<'div'>;
+
+export const FormItem = (props: FormItemProps) => {
+  const { children, className, ...restProps } = props;
+
+  const id = useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div {...restProps} className={cx(styles.formItemBase, className)}>
+        {children}
+      </div>
+    </FormItemContext.Provider>
+  );
+};

--- a/src/ui/form/form-label.styles.css.ts
+++ b/src/ui/form/form-label.styles.css.ts
@@ -1,0 +1,10 @@
+import { style } from '@vanilla-extract/css';
+import { globalVars } from '../theme.css.ts';
+import { typography } from '../typography.css.ts';
+
+export const formLabelBase = style([
+  typography('body_2_14_sb'),
+  {
+    color: globalVars.color.grey800,
+  },
+]);

--- a/src/ui/form/form-label.styles.css.ts
+++ b/src/ui/form/form-label.styles.css.ts
@@ -6,5 +6,11 @@ export const formLabelBase = style([
   typography('body_2_14_sb'),
   {
     color: globalVars.color.grey800,
+    display: 'flex',
+    gap: 4,
   },
 ]);
+
+export const requiredIcon = style({
+  color: globalVars.color.mainblue500,
+});

--- a/src/ui/form/form-label.tsx
+++ b/src/ui/form/form-label.tsx
@@ -1,0 +1,22 @@
+import { type ComponentProps } from 'react';
+import { cx } from '../util.ts';
+import { useFormField } from './form-field.tsx';
+import * as styles from './form-label.styles.css.ts';
+
+export type FormLabelProps = ComponentProps<'label'>;
+
+// TODO required 속성 지원 필요
+export const FormLabel = (props: FormLabelProps) => {
+  const { children, className, ...restProps } = props;
+
+  const { formItemId } = useFormField();
+  return (
+    <label
+      {...restProps}
+      htmlFor={formItemId}
+      className={cx(styles.formLabelBase, className)}
+    >
+      {children}
+    </label>
+  );
+};

--- a/src/ui/form/form-label.tsx
+++ b/src/ui/form/form-label.tsx
@@ -3,11 +3,12 @@ import { cx } from '../util.ts';
 import { useFormField } from './form-field.tsx';
 import * as styles from './form-label.styles.css.ts';
 
-export type FormLabelProps = ComponentProps<'label'>;
+export type FormLabelProps = ComponentProps<'label'> & {
+  required?: boolean;
+};
 
-// TODO required 속성 지원 필요
 export const FormLabel = (props: FormLabelProps) => {
-  const { children, className, ...restProps } = props;
+  const { children, className, required, ...restProps } = props;
 
   const { formItemId } = useFormField();
   return (
@@ -17,6 +18,7 @@ export const FormLabel = (props: FormLabelProps) => {
       className={cx(styles.formLabelBase, className)}
     >
       {children}
+      {required && <span className={styles.requiredIcon}>*</span>}
     </label>
   );
 };

--- a/src/ui/form/index.ts
+++ b/src/ui/form/index.ts
@@ -1,0 +1,15 @@
+export {
+  Form,
+  FormField,
+  FormItemContext,
+  useFormField,
+} from './form-field.tsx';
+
+export { FormLabel, type FormLabelProps } from './form-label.tsx';
+
+export {
+  FormErrorMessage,
+  type FormErrorMessageProps,
+} from './form-error-message.tsx';
+
+export { FormItem, type FormItemProps } from './form-item.tsx';

--- a/src/ui/input/index.ts
+++ b/src/ui/input/index.ts
@@ -1,0 +1,9 @@
+export {
+  type InputContainerProps,
+  InputContainer,
+} from './input-container.tsx';
+export { Input, type InputProps } from './input.tsx';
+export {
+  InputRightElement,
+  type InputRightElementProps,
+} from './input-element.tsx';

--- a/src/ui/input/input-container.styles.css.ts
+++ b/src/ui/input/input-container.styles.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const inputContainerBase = style({
+  position: 'relative',
+});

--- a/src/ui/input/input-container.tsx
+++ b/src/ui/input/input-container.tsx
@@ -1,0 +1,15 @@
+import { type ComponentProps } from 'react';
+import { cx } from '../util.ts';
+import * as styles from './input-container.styles.css.ts';
+
+export type InputContainerProps = ComponentProps<'div'>;
+
+export const InputContainer = (props: InputContainerProps) => {
+  const { children, className, ...restProps } = props;
+
+  return (
+    <div {...restProps} className={cx(styles.inputContainerBase, className)}>
+      {children}
+    </div>
+  );
+};

--- a/src/ui/input/input-element.styles.css.ts
+++ b/src/ui/input/input-element.styles.css.ts
@@ -1,0 +1,21 @@
+import { recipe } from '@vanilla-extract/recipes';
+
+export const inputElement = recipe({
+  base: {
+    width: 24,
+    position: 'absolute',
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  variants: {
+    direction: {
+      right: {
+        top: 0,
+        right: 12,
+      },
+    },
+  },
+});

--- a/src/ui/input/input-element.tsx
+++ b/src/ui/input/input-element.tsx
@@ -1,0 +1,20 @@
+import { ComponentProps } from 'react';
+import { cx } from '../util.ts';
+import * as styles from './input-element.styles.css.ts';
+
+type InputElementProps = ComponentProps<'div'>;
+
+export type InputRightElementProps = InputElementProps;
+
+export const InputRightElement = (props: InputRightElementProps) => {
+  const { children, className, ...restProps } = props;
+
+  return (
+    <div
+      {...restProps}
+      className={cx(styles.inputElement({ direction: 'right' }), className)}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/ui/input/input.stories.tsx
+++ b/src/ui/input/input.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DeleteCir } from '../../assets/index.ts';
+import { InputContainer } from './input-container.tsx';
+import { InputRightElement } from './input-element.tsx';
+import { Input } from './input.tsx';
+
+const meta: Meta<typeof Input> = {
+  title: 'ui/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    value: {
+      control: 'text',
+    },
+    placeholder: {
+      control: 'text',
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OnlyInput: Story = {
+  render: (args) => (
+    <InputContainer>
+      <Input {...args} />
+    </InputContainer>
+  ),
+};
+
+export const InputWithButton: Story = {
+  render: (args) => (
+    <InputContainer
+      style={{
+        width: '335px',
+      }}
+    >
+      <Input {...args} />
+      <InputRightElement>
+        <DeleteCir />
+      </InputRightElement>
+    </InputContainer>
+  ),
+};
+
+export const ErrorInput: Story = {
+  args: {
+    variant: 'error',
+    value: '에러 텍스트입니다',
+  },
+  render: (args) => (
+    <InputContainer>
+      <Input {...args} />
+    </InputContainer>
+  ),
+};
+
+export const DisabledInput: Story = {
+  args: {
+    value: 'disabled',
+    disabled: true,
+  },
+  render: (args) => (
+    <InputContainer>
+      <Input {...args} />
+    </InputContainer>
+  ),
+};

--- a/src/ui/input/input.styles.css.ts
+++ b/src/ui/input/input.styles.css.ts
@@ -1,0 +1,60 @@
+import { style } from '@vanilla-extract/css';
+import { type RecipeVariants, recipe } from '@vanilla-extract/recipes';
+import { typography } from '../typography.css.ts';
+import { globalVars } from './../theme.css.ts';
+import { inputElement } from './input-element.styles.css.ts';
+
+export const inputWithElement = style({
+  selectors: {
+    [`&:has(~ ${inputElement.classNames.variants.direction.right})`]: {
+      paddingRight: 44,
+    },
+  },
+});
+
+const base = style([
+  typography('head_3_16_r'),
+  {
+    color: globalVars.color.black,
+    backgroundColor: globalVars.color.white,
+    outline: 'none',
+    borderRadius: 6,
+    border: `1px solid ${globalVars.color.grey300}`,
+    width: '100%',
+    padding: '13px 16px',
+    boxSizing: 'border-box',
+    '::placeholder': {
+      color: globalVars.color.grey400,
+    },
+    ':focus': {
+      borderColor: globalVars.color.mainblue500,
+    },
+    ':disabled': {
+      backgroundColor: globalVars.color.grey100,
+      color: globalVars.color.grey300,
+    },
+  },
+]);
+
+export const inputVariants = recipe({
+  base,
+  variants: {
+    variant: {
+      default: {},
+      error: {
+        borderColor: globalVars.color.redDanger,
+        ':focus': {
+          borderColor: globalVars.color.redDanger,
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export type InputVariants = Exclude<
+  RecipeVariants<typeof inputVariants>,
+  undefined
+>;

--- a/src/ui/input/input.tsx
+++ b/src/ui/input/input.tsx
@@ -1,0 +1,20 @@
+import { ComponentProps } from 'react';
+import { cx } from '../util.ts';
+import * as styles from './input.styles.css.ts';
+
+type InputProps = ComponentProps<'input'> & styles.InputVariants;
+
+export const Input = (props: InputProps) => {
+  const { className, variant, ...restProps } = props;
+
+  return (
+    <input
+      {...restProps}
+      className={cx(
+        styles.inputVariants({ variant }),
+        className ?? styles.inputWithElement,
+        className,
+      )}
+    />
+  );
+};

--- a/src/ui/input/input.tsx
+++ b/src/ui/input/input.tsx
@@ -2,7 +2,7 @@ import { ComponentProps } from 'react';
 import { cx } from '../util.ts';
 import * as styles from './input.styles.css.ts';
 
-type InputProps = ComponentProps<'input'> & styles.InputVariants;
+export type InputProps = ComponentProps<'input'> & styles.InputVariants;
 
 export const Input = (props: InputProps) => {
   const { className, variant, ...restProps } = props;


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 적어주세요. -->

- close #이슈\_번호

## 작업한 목록을 작성해 주세요

<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

- Input TextField 컴포넌트를 만들었습니다.

## 스크린샷

<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->

## pr 포인트나 궁금한 점을 작성해 주세요

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

- input 컴포넌트는 그 자체로도 사용할 수 있도록 했고 form 디렉토리 내부의 컴포넌트들은 react-hook-form에 의존적인 코드들이라 구분해뒀습니다.
- input reset 버튼은 고정으로 달아주려고 했는데 피그마를 보니 전화번호 인증때에는 다른 버튼을 넣어야 하는 경우가 있더라고요. 그래서 InputElement를 이용해서 동적으로 넣을 수 있도록 했습니다.
- storybook에서 reset.css를 인식하지 못하는 이슈가 있어서 import 해놓았습니다.


연관된 issue: #18