### PR TITLE
feat: 제품 상세 페이지 성분 분포도 api 연동

### DIFF
--- a/src/apis/query/product.ts
+++ b/src/apis/query/product.ts
@@ -2,6 +2,8 @@ import { queryOptions } from '@tanstack/react-query';
 import { fetcher } from '../fetcher';
 import {
   GetProductDetailAPIReqeust,
+  GetProductDistributionAPIRequest,
+  GetProductDistributionAPIResponse,
   GetProductListAPIRequest,
   GetProductListAPIResponse,
   getProductDetailAPIResponse,
@@ -11,6 +13,7 @@ export const productQueryKeys = {
   all: () => ['product'],
   lists: () => [...productQueryKeys.all(), 'list'],
   details: () => [...productQueryKeys.all(), 'detail'],
+  distributions: () => [...productQueryKeys.all(), 'distribution'],
 };
 
 export const productQueryOption = {
@@ -23,6 +26,11 @@ export const productQueryOption = {
     queryOptions({
       queryKey: [...productQueryKeys.details(), productId],
       queryFn: () => getProductDetailAPI({ productId }),
+    }),
+  distribution: ({ productId }: GetProductDistributionAPIRequest) =>
+    queryOptions({
+      queryKey: [...productQueryKeys.distributions(), productId],
+      queryFn: () => getProductDistributionAPI({ productId }),
     }),
 };
 
@@ -52,3 +60,10 @@ const getProductListAPI = ({
 
 const getProductDetailAPI = ({ productId }: GetProductDetailAPIReqeust) =>
   fetcher.get<getProductDetailAPIResponse>(`product/${productId}`);
+
+const getProductDistributionAPI = ({
+  productId,
+}: GetProductDistributionAPIRequest) =>
+  fetcher.get<GetProductDistributionAPIResponse>(
+    `product/distribution/${productId}`,
+  );

--- a/src/apis/types/product.ts
+++ b/src/apis/types/product.ts
@@ -37,3 +37,18 @@ export type GetProductDetailAPIReqeust = {
 };
 
 export type getProductDetailAPIResponse = ResponseFormat<Product>;
+
+export type GetProductDistributionAPIRequest = {
+  productId: number;
+};
+
+export type ProductDistribution = {
+  ingredientName: string;
+  correctionAmount: number;
+  fullMark: number;
+  unit: string;
+};
+
+export type GetProductDistributionAPIResponse = ResponseFormat<
+  ProductDistribution[]
+>;

--- a/src/pages/product/components/ingredient-chart.tsx
+++ b/src/pages/product/components/ingredient-chart.tsx
@@ -1,3 +1,4 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
 import {
   PolarAngleAxis,
   PolarGrid,
@@ -5,24 +6,22 @@ import {
   RadarChart,
   ResponsiveContainer,
 } from 'recharts';
+import { productQueryOption } from '@/apis/query/product';
 
-export const IngredientChart = () => {
-  // 최대 5개
-  const rawData = [
-    { subject: '오메가3', ingredient: 120, fullMark: 150 },
-    { subject: '비타민비타민', ingredient: 98, fullMark: 150 },
-    { subject: '유산균', ingredient: 86, fullMark: 150 },
-  ];
+export const IngredientChart = ({ productId }: { productId: number }) => {
+  const {
+    data: { data: distribution },
+  } = useSuspenseQuery(productQueryOption.distribution({ productId }));
 
-  const formatData = (rawData: any) => {
-    const missingCount = 5 - rawData.length; // 부족한 개수 계산
+  const createdChartData = (distribution: any) => {
+    const missingCount = 5 - distribution.length; // 부족한 개수 계산
     const extraSpaces = Array.from({ length: missingCount }, (_, i) => ({
-      subject: ' '.repeat(i + 1), // 공백 개수 차이로 구분
-      ingredient: 0,
+      ingredientName: ' '.repeat(i + 1), // 공백 개수 차이로 구분
+      correctionAmount: 0,
       fullMark: 150,
     }));
 
-    return [...rawData, ...extraSpaces];
+    return [...distribution, ...extraSpaces];
   };
 
   return (
@@ -31,7 +30,7 @@ export const IngredientChart = () => {
         cx="50%"
         cy="50%"
         outerRadius="80%"
-        data={formatData(rawData)}
+        data={createdChartData(distribution)}
       >
         <defs>
           <linearGradient id="gradientFill" x1="0" y1="0" x2="0" y2="1">
@@ -43,7 +42,7 @@ export const IngredientChart = () => {
         </defs>
         <PolarGrid />
         <PolarAngleAxis
-          dataKey="subject"
+          dataKey="ingredientName"
           tick={{
             fill: '#3366FF',
             fontFamily: 'Pretendard',
@@ -52,7 +51,7 @@ export const IngredientChart = () => {
           }}
         />
         <Radar
-          dataKey="ingredient"
+          dataKey="correctionAmount"
           stroke="#6666FF"
           fill="url(#gradientFill)"
           fillOpacity={0.6}

--- a/src/pages/product/index.tsx
+++ b/src/pages/product/index.tsx
@@ -155,7 +155,7 @@ export const ProductPageInner = ({ productId }: { productId: number }) => {
             </ButtonText>
           </div>
           <div className={styles.chartBox}>
-            <IngredientChart />
+            <IngredientChart productId={productId} />
           </div>
         </section>
         <Spacer size={10} className={styles.spaceColor} />

--- a/src/pages/product/page.css.ts
+++ b/src/pages/product/page.css.ts
@@ -53,6 +53,7 @@ export const won = style([
 export const tags = style([
   {
     display: 'flex',
+    flexWrap: 'wrap',
     gap: 4,
   },
 ]);


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 적어주세요. -->

- close #118 

## 작업한 목록을 작성해 주세요

<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

- 제품 성분 분포도 조회 API 연동했습니다. 기존 api참고해서 했는데 맞는지 모르겠네요..

## 스크린샷

<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->

## pr 포인트나 궁금한 점을 작성해 주세요

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

- 제품 목록 조회, 제품 단건 조회 두개 api가 있는데 쿼리스트링으로 들어가냐 아니냐의 차이더라고요... 
- 제품 단건 조회 api는 사용 안했습니다.
- queryOptions 처음 써보는데 해당 방식으로 쓰니 개발하기 편한거 같습니다👍
- 제품 상세에서 구매 링크 쪽 추가해야될거 같습니다. (일단 뻄)

연관된 issue: #118