### PR TITLE
feat: 내 약통 관련 api 연동

### DIFF
--- a/src/apis/mutation/myMedicine.ts
+++ b/src/apis/mutation/myMedicine.ts
@@ -1,0 +1,13 @@
+import { fetcher } from '../fetcher';
+import {
+  AddMyMedicineAPIRequest,
+  AddMyMedicineAPIResponse,
+  DeleteMyMedicineAPIRequest,
+} from '../types/myMedicine';
+
+export const addMyMedicineAPI = (data: AddMyMedicineAPIRequest) =>
+  fetcher.post<AddMyMedicineAPIResponse>('my-medicine', { json: data });
+
+export const deleteMyMedicineAPI = ({
+  myMedicineId,
+}: DeleteMyMedicineAPIRequest) => fetcher.delete(`my-medicine/${myMedicineId}`);

--- a/src/apis/query/myMedicine.ts
+++ b/src/apis/query/myMedicine.ts
@@ -1,0 +1,19 @@
+import { queryOptions } from '@tanstack/react-query';
+import { fetcher } from '../fetcher';
+import { GetMyMedicineAPIResponse } from '../types/myMedicine';
+
+const myMedicineQueryKeys = {
+  all: () => ['myMedicine'],
+  lists: () => [...myMedicineQueryKeys.all(), 'list'],
+};
+
+export const myMedicneQueryOption = {
+  list: () =>
+    queryOptions({
+      queryKey: [...myMedicineQueryKeys.all()],
+      queryFn: getUserInfoAPI,
+    }),
+};
+
+const getUserInfoAPI = () =>
+  fetcher.get<GetMyMedicineAPIResponse>('myMedicine');

--- a/src/apis/query/myMedicine.ts
+++ b/src/apis/query/myMedicine.ts
@@ -16,4 +16,4 @@ export const myMedicneQueryOption = {
 };
 
 const getUserInfoAPI = () =>
-  fetcher.get<GetMyMedicineAPIResponse>('myMedicine');
+  fetcher.get<GetMyMedicineAPIResponse>('my-medicine');

--- a/src/apis/query/myMedicine.ts
+++ b/src/apis/query/myMedicine.ts
@@ -2,7 +2,7 @@ import { queryOptions } from '@tanstack/react-query';
 import { fetcher } from '../fetcher';
 import { GetMyMedicineAPIResponse } from '../types/myMedicine';
 
-const myMedicineQueryKeys = {
+export const myMedicineQueryKeys = {
   all: () => ['myMedicine'],
   lists: () => [...myMedicineQueryKeys.all(), 'list'],
 };

--- a/src/apis/types/myMedicine.ts
+++ b/src/apis/types/myMedicine.ts
@@ -1,0 +1,14 @@
+import { ResponseFormat } from './common';
+import { Product } from './product';
+
+export type GetMyMedicineAPIResponse = ResponseFormat<Product[]>;
+
+export type AddMyMedicineAPIRequest = {
+  productId: number;
+};
+
+export type AddMyMedicineAPIResponse = ResponseFormat<Product>;
+
+export type DeleteMyMedicineAPIRequest = {
+  myMedicineId: number;
+};

--- a/src/apis/types/myMedicine.ts
+++ b/src/apis/types/myMedicine.ts
@@ -1,7 +1,9 @@
 import { ResponseFormat } from './common';
 import { Product } from './product';
 
-export type GetMyMedicineAPIResponse = ResponseFormat<Product[]>;
+export type GetMyMedicineAPIResponse = ResponseFormat<
+  Array<{ product: Product }>
+>;
 
 export type AddMyMedicineAPIRequest = {
   productId: number;

--- a/src/apis/types/myMedicine.ts
+++ b/src/apis/types/myMedicine.ts
@@ -9,7 +9,7 @@ export type AddMyMedicineAPIRequest = {
   productId: number;
 };
 
-export type AddMyMedicineAPIResponse = ResponseFormat<Product>;
+export type AddMyMedicineAPIResponse = ResponseFormat<{ product: Product }>;
 
 export type DeleteMyMedicineAPIRequest = {
   myMedicineId: number;

--- a/src/apis/types/product.ts
+++ b/src/apis/types/product.ts
@@ -7,21 +7,17 @@ export type Product = {
   imageUrl: string;
   purchaseLink: string;
   description: string;
-  healthConcerns: [
-    {
-      id: number;
-      name: string;
-      description: string;
-      imageUrl: string;
-    },
-  ];
-  productIngredients: [
-    {
-      ingredientName: string;
-      amount: number;
-      unit: string;
-    },
-  ];
+  healthConcerns: Array<{
+    id: number;
+    name: string;
+    description: string;
+    imageUrl: string;
+  }>;
+  productIngredients: Array<{
+    ingredientName: string;
+    amount: number;
+    unit: string;
+  }>;
 };
 
 export type GetProductListAPIRequest = {

--- a/src/apis/types/product.ts
+++ b/src/apis/types/product.ts
@@ -1,6 +1,6 @@
 import { ResponseFormat } from './common';
 
-type Product = {
+export type Product = {
   id: number;
   name: string;
   price: number;

--- a/src/pages/pillbox/index.tsx
+++ b/src/pages/pillbox/index.tsx
@@ -14,19 +14,11 @@ import * as styles from './page.css';
 
 export const PillboxPage = () => {
   return (
-    <PageLayout
-      header={
-        <AppBar right={<Cart />} variant="default">
-          내 약통
-        </AppBar>
-      }
-    >
-      <LocalErrorBoundary>
-        <Suspense>
-          <PillboxPageInner />
-        </Suspense>
-      </LocalErrorBoundary>
-    </PageLayout>
+    <LocalErrorBoundary>
+      <Suspense>
+        <PillboxPageInner />
+      </Suspense>
+    </LocalErrorBoundary>
   );
 };
 
@@ -39,7 +31,13 @@ const PillboxPageInner = () => {
   } = useSuspenseQuery(myMedicneQueryOption.list());
 
   return (
-    <>
+    <PageLayout
+      header={
+        <AppBar right={<Cart />} variant="default">
+          내 약통
+        </AppBar>
+      }
+    >
       <Spacer size={37} />
       <section className={styles.boxContainer}>
         <div className={styles.boxTitle}>필미님의 약통</div>
@@ -144,6 +142,6 @@ const PillboxPageInner = () => {
           </section>
         </BottomSheet.Content>
       </BottomSheet.Root>
-    </>
+    </PageLayout>
   );
 };

--- a/src/pages/pillbox/index.tsx
+++ b/src/pages/pillbox/index.tsx
@@ -1,5 +1,8 @@
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { myMedicneQueryOption } from '@/apis/query/myMedicine';
 import { Cart, Intake, Notice, PillBox, PlusBlue } from '@/assets';
+import { LocalErrorBoundary } from '@/components/LocalErrorBoundary';
 import * as bottomStyles from '@/pages/product/ingredient/bottomSheet.css';
 import { AppBar } from '@/ui/app-bar';
 import { BottomSheet } from '@/ui/bottom-sheet/bottom-sheet';
@@ -10,9 +13,6 @@ import { IngredientGraph } from '../product/components/ingredient-graph';
 import * as styles from './page.css';
 
 export const PillboxPage = () => {
-  const pillData = [];
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
     <PageLayout
       header={
@@ -21,10 +21,29 @@ export const PillboxPage = () => {
         </AppBar>
       }
     >
+      <LocalErrorBoundary>
+        <Suspense>
+          <PillboxPageInner />
+        </Suspense>
+      </LocalErrorBoundary>
+    </PageLayout>
+  );
+};
+
+const PillboxPageInner = () => {
+  const pillData = [];
+  const [isOpen, setIsOpen] = useState(false);
+
+  const {
+    data: { data: medicineList },
+  } = useSuspenseQuery(myMedicneQueryOption.list());
+
+  return (
+    <>
       <Spacer size={37} />
       <section className={styles.boxContainer}>
         <div className={styles.boxTitle}>필미님의 약통</div>
-        {pillData.length === 0 ? (
+        {medicineList.length === 0 ? (
           <div className={styles.myPillBox}>
             <PlusBlue />
             <span className={styles.boxDesc}>
@@ -33,6 +52,7 @@ export const PillboxPage = () => {
             <PillBox className={styles.boxIcon} />
           </div>
         ) : (
+          //TODO ui 추가 필요
           <div>약</div>
         )}
       </section>
@@ -124,6 +144,6 @@ export const PillboxPage = () => {
           </section>
         </BottomSheet.Content>
       </BottomSheet.Root>
-    </PageLayout>
+    </>
   );
 };

--- a/src/pages/pillbox/manage/index.tsx
+++ b/src/pages/pillbox/manage/index.tsx
@@ -17,38 +17,18 @@ import { Checkbox } from '../../../ui/check-box/check-box';
 import * as styles from './page.css';
 
 export const PillboxManagePage = () => {
-  const navigate = useNavigate();
-  const goBack = () => navigate(-1);
-
   return (
-    <PageLayout
-      header={
-        <div>
-          <AppBar
-            left={
-              <IconButton onClick={goBack}>
-                <ArrowLeft />
-              </IconButton>
-            }
-            variant="page"
-          >
-            내 약통 관리
-          </AppBar>
-          <div className={styles.separator} />
-        </div>
-      }
-    >
-      <LocalErrorBoundary>
-        <Suspense>
-          <PillboxManagePageInner />
-        </Suspense>
-      </LocalErrorBoundary>
-    </PageLayout>
+    <LocalErrorBoundary>
+      <Suspense>
+        <PillboxManagePageInner />
+      </Suspense>
+    </LocalErrorBoundary>
   );
 };
 
 const PillboxManagePageInner = () => {
   const navigate = useNavigate();
+  const goBack = () => navigate(-1);
   const goAddPillboxPage = () => navigate('/pillbox/new');
 
   const {
@@ -81,7 +61,23 @@ const PillboxManagePageInner = () => {
   const allChecked = productList.every(({ checked }) => Boolean(checked));
 
   return (
-    <>
+    <PageLayout
+      header={
+        <div>
+          <AppBar
+            left={
+              <IconButton onClick={goBack}>
+                <ArrowLeft />
+              </IconButton>
+            }
+            variant="page"
+          >
+            내 약통 관리
+          </AppBar>
+          <div className={styles.separator} />
+        </div>
+      }
+    >
       <div className={styles.container}>
         <p className={styles.totalCount}>총 2개</p>
         <Spacer size={20} />
@@ -169,6 +165,6 @@ const PillboxManagePageInner = () => {
           </Button>
         </div>
       </div>
-    </>
+    </PageLayout>
   );
 };

--- a/src/pages/pillbox/manage/index.tsx
+++ b/src/pages/pillbox/manage/index.tsx
@@ -139,7 +139,7 @@ const PillboxManagePageInner = () => {
                         {name}
                       </Chip>
                     ))}
-                    {productIngredients.map(({ ingredientName }, index) => (
+                    {productIngredients.map(({ ingredientName }) => (
                       <Chip
                         shape="tag"
                         backgroundColor="grey200"

--- a/src/pages/pillbox/manage/index.tsx
+++ b/src/pages/pillbox/manage/index.tsx
@@ -1,7 +1,9 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, Suspense, useState } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
+import { myMedicneQueryOption } from '@/apis/query/myMedicine';
 import { ArrowLeft } from '@/assets';
-import { MOCK_PRODUCT_LIST } from '@/pages/home/mock-product';
+import { LocalErrorBoundary } from '@/components/LocalErrorBoundary';
 import { AppBar } from '@/ui/app-bar';
 import { Button } from '@/ui/button';
 import { ButtonText } from '@/ui/button-text';
@@ -14,22 +16,51 @@ import { Spacer } from '@/ui/spacer/spacer';
 import { Checkbox } from '../../../ui/check-box/check-box';
 import * as styles from './page.css';
 
-const MOCK_TAG_LIST = [
-  { name: '혈압', type: 'category' },
-  { name: '루테인', type: 'ingredient' },
-] satisfies Array<{ name: string; type: 'category' | 'ingredient' }>;
-
 export const PillboxManagePage = () => {
   const navigate = useNavigate();
-
   const goBack = () => navigate(-1);
 
-  const [productList, setProductList] = useState(
-    MOCK_PRODUCT_LIST.map((product) => ({
-      ...product,
-      checked: true,
-    })),
+  return (
+    <PageLayout
+      header={
+        <div>
+          <AppBar
+            left={
+              <IconButton onClick={goBack}>
+                <ArrowLeft />
+              </IconButton>
+            }
+            variant="page"
+          >
+            내 약통 관리
+          </AppBar>
+          <div className={styles.separator} />
+        </div>
+      }
+    >
+      <LocalErrorBoundary>
+        <Suspense>
+          <PillboxManagePageInner />
+        </Suspense>
+      </LocalErrorBoundary>
+    </PageLayout>
   );
+};
+
+const PillboxManagePageInner = () => {
+  const navigate = useNavigate();
+  const goAddPillboxPage = () => navigate('/pillbox/new');
+
+  const {
+    data: { data: medicneList },
+  } = useSuspenseQuery(myMedicneQueryOption.list());
+
+  const initialProductList = medicneList.map(({ product }) => ({
+    ...product,
+    checked: true,
+  }));
+
+  const [productList, setProductList] = useState(initialProductList);
 
   const toggleCheck = ({ target: { id } }: ChangeEvent) => {
     const updatedProductList = productList.map((product) =>
@@ -50,23 +81,7 @@ export const PillboxManagePage = () => {
   const allChecked = productList.every(({ checked }) => Boolean(checked));
 
   return (
-    <PageLayout
-      header={
-        <div>
-          <AppBar
-            left={
-              <IconButton onClick={goBack}>
-                <ArrowLeft />
-              </IconButton>
-            }
-            variant="page"
-          >
-            내 약통 관리
-          </AppBar>
-          <div className={styles.separator} />
-        </div>
-      }
-    >
+    <>
       <div className={styles.container}>
         <p className={styles.totalCount}>총 2개</p>
         <Spacer size={20} />
@@ -90,43 +105,70 @@ export const PillboxManagePage = () => {
         </div>
         <Spacer size={30} />
         <div className={styles.list}>
-          {productList.map(({ id, checked, ...rest }) => (
-            <HorizontalCard
-              {...rest}
-              key={id}
-              label={
-                <Checkbox
-                  id={String(id)}
-                  checked={checked}
-                  onChange={toggleCheck}
-                  className={styles.checkbox}
-                />
-              }
-            >
-              {MOCK_TAG_LIST && (
-                <div className={styles.chipContainer}>
-                  {MOCK_TAG_LIST.map(({ name, type }, index) => (
-                    <Chip
-                      shape="tag"
-                      backgroundColor={
-                        type === 'category' ? 'blue200' : 'grey200'
-                      }
-                      color={type === 'category' ? 'blue400' : 'grey500'}
-                      typography="body_4_12_b"
-                      key={index}
-                    >
-                      {name}
-                    </Chip>
-                  ))}
-                </div>
-              )}
-            </HorizontalCard>
-          ))}
-          <Button size="large" variant="third" className={styles.button}>
+          {productList.map(
+            ({
+              id,
+              checked,
+              imageUrl,
+              description,
+              name,
+              healthConcerns,
+              productIngredients,
+            }) => (
+              <HorizontalCard
+                key={id}
+                imageUrl={imageUrl}
+                company={description}
+                name={name}
+                label={
+                  <Checkbox
+                    id={String(id)}
+                    checked={checked}
+                    onChange={toggleCheck}
+                    className={styles.checkbox}
+                  />
+                }
+              >
+                {(healthConcerns.length !== 0 ||
+                  productIngredients.length !== 0) && (
+                  <div className={styles.chipContainer}>
+                    {healthConcerns.map(({ id, name }) => (
+                      <Chip
+                        shape="tag"
+                        backgroundColor="blue200"
+                        color="blue400"
+                        typography="body_4_12_b"
+                        key={id}
+                      >
+                        {name}
+                      </Chip>
+                    ))}
+                    {productIngredients.map(({ ingredientName }, index) => (
+                      <Chip
+                        shape="tag"
+                        backgroundColor="grey200"
+                        color="grey500"
+                        typography="body_4_12_b"
+                        key={ingredientName}
+                      >
+                        {ingredientName}
+                      </Chip>
+                    ))}
+                  </div>
+                )}
+              </HorizontalCard>
+            ),
+          )}
+          <Button
+            size="large"
+            variant="third"
+            className={styles.button}
+            onClick={goAddPillboxPage}
+          >
             복용 제품 추가
           </Button>
         </div>
       </div>
-    </PageLayout>
+    </>
   );
 };

--- a/src/pages/pillbox/manage/page.css.ts
+++ b/src/pages/pillbox/manage/page.css.ts
@@ -57,4 +57,5 @@ export const chipContainer = style({
   display: 'flex',
   alignItems: 'center',
   gap: 4,
+  flexWrap: 'wrap',
 });

--- a/src/pages/pillbox/new/components/PillBoxCardList.tsx
+++ b/src/pages/pillbox/new/components/PillBoxCardList.tsx
@@ -1,31 +1,99 @@
+import { useState } from 'react';
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
+import { addMyMedicineAPI } from '@/apis/mutation/myMedicine';
+import { myMedicineQueryKeys } from '@/apis/query/myMedicine';
+import { productQueryOption } from '@/apis/query/product';
+import { Product } from '@/apis/types/product';
+import { Check, Plus } from '@/assets';
 import { Button } from '@/ui/button';
 import { Spacer } from '@/ui/spacer/spacer';
+import { useShowCustomToast } from '@/ui/toast/toast';
 import * as styles from './PillBoxCardList.css';
 
-export const PillBoxCardList = () => {
+export const PillBoxCardList = ({ keyword }: { keyword: string }) => {
+  const showCustomToast = useShowCustomToast();
+
+  const queryClient = useQueryClient();
+
+  const {
+    data: { data: fetchedProductList },
+  } = useSuspenseQuery(productQueryOption.list({ search: keyword }));
+
+  const initialProductList = fetchedProductList.map((product) => ({
+    ...product,
+    checked: false,
+  }));
+
+  const [productList, setProductList] = useState(initialProductList);
+
+  const { mutate } = useMutation({
+    mutationFn: addMyMedicineAPI,
+    onSuccess: ({
+      data: {
+        product: { id },
+      },
+    }) => {
+      showCustomToast('내 약통에 추가 되었어요', 'success', '/pillbox/manage');
+      setProductList((prev) =>
+        prev.map((product) => ({
+          ...product,
+          checked: id === product.id,
+        })),
+      );
+      queryClient.invalidateQueries({
+        queryKey: [...myMedicineQueryKeys.lists()],
+      });
+    },
+  });
+
+  const onClickSaveButton = (productId: number) => () => {
+    mutate({ productId });
+  };
+
   return (
     <div className={styles.pillboxCardListContainer}>
-      <PillBoxCard />
-      <PillBoxCard />
-      <PillBoxCard />
-      <PillBoxCard />
-      <PillBoxCard />
-      <PillBoxCard />
+      {productList.map((product) => (
+        <PillBoxCard
+          key={product.id}
+          {...product}
+          onClickSaveButton={onClickSaveButton(product.id)}
+        />
+      ))}
     </div>
   );
 };
 
-export const PillBoxCard = () => {
+type PillBoxCardProps = {
+  onClickSaveButton: VoidFunction;
+  checked?: boolean;
+} & Product;
+
+export const PillBoxCard = ({
+  name,
+  imageUrl,
+  description,
+  onClickSaveButton,
+  checked = false,
+}: PillBoxCardProps) => {
   return (
     <div className={styles.cardContainer}>
-      <img className={styles.image} src="https://picsum.photos/200/300" />
+      <img className={styles.image} src={imageUrl} />
       <div className={styles.cardRight}>
         <div>
-          <p className={styles.description}>제약사 브랜드 입력00000</p>
+          <p className={styles.description}>{description}</p>
           <Spacer size={6} />
-          <p className={styles.title}>웰릿나토킨NATOTOKIN최대글자최대글자</p>
+          <p className={styles.title}>{name}</p>
         </div>
-        <Button variant="third" size="small">
+        <Button
+          variant="third"
+          size="small"
+          onClick={onClickSaveButton}
+          left={checked ? <Check /> : <Plus />}
+        >
           내 약통
         </Button>
       </div>

--- a/src/pages/pillbox/new/index.tsx
+++ b/src/pages/pillbox/new/index.tsx
@@ -45,33 +45,34 @@ export const PillboxNewPage = () => {
   };
 
   return (
-    <PageLayout
-      header={
-        <AppBar
-          left={
-            <AppBarElement onClick={goBack}>
-              <ArrowLeft />
-            </AppBarElement>
-          }
-          variant="page"
-        >
-          복용 제품 추가
-        </AppBar>
-      }
-    >
-      <div className={styles.searchFieldContainer}>
-        <form onSubmit={onSubmit}>
-          <SearchField
-            disabled={!isSearching}
-            inputMode="search"
-            value={searchedKeyword ?? keyword}
-            onChange={onChange}
-            hasResetButton={isSearching && keyword.length !== 0}
-            onClickResetButton={onClickResetButton}
-          />
-        </form>
-      </div>
-      <LocalErrorBoundary>
+    <LocalErrorBoundary>
+      <PageLayout
+        header={
+          <AppBar
+            left={
+              <AppBarElement onClick={goBack}>
+                <ArrowLeft />
+              </AppBarElement>
+            }
+            variant="page"
+          >
+            복용 제품 추가
+          </AppBar>
+        }
+      >
+        <div className={styles.searchFieldContainer}>
+          <form onSubmit={onSubmit}>
+            <SearchField
+              disabled={!isSearching}
+              inputMode="search"
+              value={searchedKeyword ?? keyword}
+              onChange={onChange}
+              hasResetButton={isSearching && keyword.length !== 0}
+              onClickResetButton={onClickResetButton}
+            />
+          </form>
+        </div>
+
         {isSearching ? (
           <SearchingKeywordList keyword={keyword} />
         ) : (
@@ -79,7 +80,7 @@ export const PillboxNewPage = () => {
             <PillBoxCardList keyword={searchedKeyword} />
           </Suspense>
         )}
-      </LocalErrorBoundary>
-    </PageLayout>
+      </PageLayout>
+    </LocalErrorBoundary>
   );
 };

--- a/src/pages/pillbox/new/index.tsx
+++ b/src/pages/pillbox/new/index.tsx
@@ -1,6 +1,12 @@
-import { ChangeEventHandler, FormEventHandler, useState } from 'react';
+import {
+  ChangeEventHandler,
+  FormEventHandler,
+  Suspense,
+  useState,
+} from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import { ArrowLeft } from '@/assets';
+import { LocalErrorBoundary } from '@/components/LocalErrorBoundary';
 import { AppBar, AppBarElement } from '@/ui/app-bar';
 import { PageLayout } from '@/ui/layout/page-layout';
 import { SearchField } from '@/ui/search-field';
@@ -58,18 +64,22 @@ export const PillboxNewPage = () => {
           <SearchField
             disabled={!isSearching}
             inputMode="search"
-            value={keyword}
+            value={searchedKeyword ?? keyword}
             onChange={onChange}
             hasResetButton={isSearching && keyword.length !== 0}
             onClickResetButton={onClickResetButton}
           />
         </form>
       </div>
-      {isSearching ? (
-        <SearchingKeywordList keyword={keyword} />
-      ) : (
-        <PillBoxCardList />
-      )}
+      <LocalErrorBoundary>
+        {isSearching ? (
+          <SearchingKeywordList keyword={keyword} />
+        ) : (
+          <Suspense>
+            <PillBoxCardList keyword={searchedKeyword} />
+          </Suspense>
+        )}
+      </LocalErrorBoundary>
     </PageLayout>
   );
 };

--- a/src/pages/product/index.tsx
+++ b/src/pages/product/index.tsx
@@ -1,7 +1,11 @@
 import { Suspense, useState } from 'react';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { motion } from 'motion/react';
 import { useNavigate, useParams } from 'react-router';
+import {
+  addMyMedicineAPI,
+  deleteMyMedicineAPI,
+} from '@/apis/mutation/myMedicine';
 import { productQueryOption } from '@/apis/query/product';
 import { ArrowLeft, Check, Plus } from '@/assets';
 import { CartButton } from '@/components/cart-botton';
@@ -39,13 +43,27 @@ export const ProductPageInner = ({ productId }: { productId: number }) => {
     data: { data: product },
   } = useSuspenseQuery(productQueryOption.detail({ productId }));
 
+  const { mutate: addaddMyMedicineMutate } = useMutation({
+    mutationFn: addMyMedicineAPI,
+    onSuccess: () => {
+      showCustomToast('내 약통에 추가 되었어요', 'success', '/pillbox/manage');
+      setIsAddedToPillbox(true);
+    },
+  });
+
+  const { mutate: deleteMyMedicineMutate } = useMutation({
+    mutationFn: deleteMyMedicineAPI,
+    onSuccess: () => {
+      showCustomToast('내 약통에서 삭제되었어요', 'remove', '/pillbox/manage');
+      setIsAddedToPillbox(false);
+    },
+  });
+
   const handlePillboxClick = () => {
-    setIsAddedToPillbox(true);
-    showCustomToast('내 약통에 추가 되었어요', 'success', '/pillbox/manage');
+    addaddMyMedicineMutate({ productId: product.id });
   };
   const handleRemoveFromPillbox = () => {
-    setIsAddedToPillbox(false);
-    showCustomToast('내 약통에서 삭제되었어요', 'remove', '/pillbox/manage');
+    deleteMyMedicineMutate({ myMedicineId: product.id });
   };
 
   return (
@@ -134,7 +152,7 @@ export const ProductPageInner = ({ productId }: { productId: number }) => {
                     variant="third"
                     left={<Check />}
                     className={styles.pillButton}
-                    onClick={handlePillboxClick}
+                    onClick={handleRemoveFromPillbox}
                   >
                     내 약통
                   </Button>

--- a/src/pages/search/result/index.tsx
+++ b/src/pages/search/result/index.tsx
@@ -25,45 +25,45 @@ export const SearchResultPage = () => {
   const { searchType } = useParams();
 
   return (
-    <PageLayout
-      header={
+    <LocalErrorBoundary>
+      <PageLayout
+        header={
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25, ease: 'easeInOut' }}
+            exit={{ opacity: 0, y: 20 }}
+          >
+            <AppBar
+              left={<ArrowLeft onClick={() => navigate(-1)} />}
+              right={<CartButton />}
+              variant="page"
+              className={styles.header}
+            >
+              <div className={styles.searchContainer}>
+                <SearchField
+                  hasResetButton
+                  placeholder="건강 불편 증상을 검색해 보세요"
+                  value={keyword}
+                />
+              </div>
+            </AppBar>
+          </motion.div>
+        }
+      >
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.25, ease: 'easeInOut' }}
+          transition={{ duration: 0.25, ease: 'easeInOut', delay: 0.2 }}
           exit={{ opacity: 0, y: 20 }}
+          className={styles.mainContainer}
         >
-          <AppBar
-            left={<ArrowLeft onClick={() => navigate(-1)} />}
-            right={<CartButton />}
-            variant="page"
-            className={styles.header}
-          >
-            <div className={styles.searchContainer}>
-              <SearchField
-                hasResetButton
-                placeholder="건강 불편 증상을 검색해 보세요"
-                value={keyword}
-              />
-            </div>
-          </AppBar>
-        </motion.div>
-      }
-    >
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.25, ease: 'easeInOut', delay: 0.2 }}
-        exit={{ opacity: 0, y: 20 }}
-        className={styles.mainContainer}
-      >
-        <LocalErrorBoundary>
           <Suspense fallback={<></>}>
             <SearchResultPageInner searchType={searchType} keyword={keyword} />
           </Suspense>
-        </LocalErrorBoundary>
-      </motion.div>
-    </PageLayout>
+        </motion.div>
+      </PageLayout>
+    </LocalErrorBoundary>
   );
 };
 

--- a/src/pages/userinfo/components/GenderStepFunnel.tsx
+++ b/src/pages/userinfo/components/GenderStepFunnel.tsx
@@ -18,7 +18,7 @@ export const GenderStepFunnel = () => {
 
   useEffect(() => {
     setFocus('gender');
-  }, []);
+  }, [setFocus]);
 
   return (
     <>


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 적어주세요. -->

- close #121

## 작업한 목록을 작성해 주세요

<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

- 상세 페이지에서 약통에 추가, 삭제하는 api 연동
- 내 약통 페이지에서 약 목록 조회 api 연동 -> ui가 구현이 안돼있습니다
- 내 약통 관리 페이지 약 목록 조회 api 연동
- 내 약통 추가 페이지 검색 및 내 약통에 추가 api 연동

## 스크린샷

<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->

## pr 포인트나 궁금한 점을 작성해 주세요

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

- 약통에서 삭제하는 건 백엔드에서 다건 삭제 api가 나오면 연동하려고 합니다
- 키워드 자동완성도 백엔드가 완성되면 연결하려고 합니다
- 약을 조회할때 태그들이 많을 경우 어떻게 보여줄 지 논의가 필요할 것 같습니다
- 같은 종류의 약을 내 약통에 추가했을 때 중복으로 보이는 데 논의가 필요할 것 같습니다

연관된 issue: #121